### PR TITLE
Fix White Rectangle in "e" of "Claude" Update Text.tsx

### DIFF
--- a/src/Claude/components/Text.tsx
+++ b/src/Claude/components/Text.tsx
@@ -8,7 +8,7 @@ const Icon: IconType = forwardRef(({ size = '1em', style, ...rest }, ref) => {
   return (
     <svg
       fill="currentColor"
-      fillRule="evenodd"
+      fillRule="nonzero"
       height={size}
       ref={ref}
       style={{ flex: 'none', lineHeight: 1, width: 'fit-content', ...style }}


### PR DESCRIPTION
This PR addresses an issue with the "e" in "Claude" where a small white rectangle was visible due to font design overlap. I've adjusted the fill rule to eliminate this visual artifact.


#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [X] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

Updated the fill rule to correct the overlapping issue in the font design, ensuring a clean appearance for the "e" in "Claude".

#### 📝 补充信息 | Additional Information

[fill-rule](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill-rule)

<img width="725" alt="image" src="https://github.com/user-attachments/assets/db8a03a2-281e-4b7a-b6e3-93c575348bde">

<img width="908" alt="image" src="https://github.com/user-attachments/assets/cd1778e6-db5c-44ff-ab6d-4e6f873cae1a">

<img width="817" alt="image" src="https://github.com/user-attachments/assets/790f2966-b9cb-43e3-a1b6-f11b14f413a1">
