### PR TITLE
🐛 fix: Yi & Solar icon display in TogetherAI provider

### DIFF
--- a/src/ModelIcon/const.ts
+++ b/src/ModelIcon/const.ts
@@ -85,7 +85,7 @@ export const modelMappings: ModelMapping[] = [
   { Icon: Minimax, keywords: ['minmax', 'abab'] },
   { Icon: Mistral, keywords: ['mistral', 'mixtral', 'codestral', 'mathstral', '/mn-'] },
   { Icon: Perplexity, keywords: ['pplx', 'sonar'] },
-  { Icon: Yi, keywords: ['^yi-', '/yi-'] },
+  { Icon: Yi, keywords: ['^yi-', '/yi-', '-yi-'] },
   { Icon: OpenRouter, keywords: ['^openrouter'] },
   { Icon: OpenChat, keywords: ['^openchat'] },
   { Icon: Aya, keywords: ['aya'] },
@@ -121,7 +121,7 @@ export const modelMappings: ModelMapping[] = [
   { Icon: Adobe, keywords: ['firefly'] },
   { Icon: Ai21, keywords: ['jamba', '^j2-'] },
   { Icon: InternLM, keywords: ['internlm'] },
-  { Icon: Upstage, keywords: ['^solar-'] },
+  { Icon: Upstage, keywords: ['^solar-', '/solar'] },
   { Icon: PaLM, keywords: ['palm'] },
   { Icon: Google, keywords: ['google'] },
   {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [X] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

支持 Together AI 模型命名格式

Yi: `NousResearch/Nous-Hermes-2-Yi-34B`
Solar: `upstage/SOLAR-10.7B-Instruct-v1.0`

https://docs.together.ai/docs/chat-models

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

![image](https://github.com/user-attachments/assets/9abf8cfb-74b3-4a74-aba0-ddd34357210c)

<!-- Add any other context about the Pull Request here. -->
