### PR TITLE
 💄 style: Add AlibabaCloud icon for Qwen

### DIFF
--- a/src/features/providerConfig.tsx
+++ b/src/features/providerConfig.tsx
@@ -4,6 +4,7 @@ import { FC, memo } from 'react';
 import Ai21 from '@/Ai21';
 import Ai360 from '@/Ai360';
 import AiMass from '@/AiMass';
+import AlibabaCloud from '@/AlibabaCloud';
 import Anthropic from '@/Anthropic';
 import Aws from '@/Aws';
 import Azure from '@/Azure';
@@ -159,16 +160,19 @@ export const providerMappings: ProviderMapping[] = [
   { Icon: ZeroOne, combineMultiple: 0.9, keywords: [ModelProvider.ZeroOne] },
   { Icon: Together, keywords: [ModelProvider.TogetherAI] },
   { Icon: Qiniu, combineMultiple: 1.1, keywords: [ModelProvider.Qiniu] },
-  { 
+  {
     Combine: memo(({ size = 24, type = 'color', ...props }) => (
       <Combine
-        left={type === 'color' ? <Aws.Color size={size * 1.2} /> : <Aws size={size * 1.2} />}
-        right={<Bedrock.Combine size={size} type={type} />}
+        left={<AlibabaCloud.Combine size={size} type={type} />}
+        right={<Qwen.Combine size={size} type={type} />}
         size={size}
         {...props}
       />
     )),
-    Icon: Qwen, keywords: [ModelProvider.Qwen] },
+    Icon: Qwen,
+    combineMultiple: 1.1,
+    keywords: [ModelProvider.Qwen],
+  },
   { Icon: Stepfun, combineMultiple: 0.83, keywords: [ModelProvider.Stepfun] },
   { Icon: Spark, combineMultiple: 0.92, keywords: [ModelProvider.Spark] },
   { Icon: Fireworks, combineMultiple: 1.14, keywords: [ModelProvider.FireworksAI] },

--- a/src/features/providerConfig.tsx
+++ b/src/features/providerConfig.tsx
@@ -159,7 +159,16 @@ export const providerMappings: ProviderMapping[] = [
   { Icon: ZeroOne, combineMultiple: 0.9, keywords: [ModelProvider.ZeroOne] },
   { Icon: Together, keywords: [ModelProvider.TogetherAI] },
   { Icon: Qiniu, combineMultiple: 1.1, keywords: [ModelProvider.Qiniu] },
-  { Icon: Qwen, keywords: [ModelProvider.Qwen] },
+  { 
+    Combine: memo(({ size = 24, type = 'color', ...props }) => (
+      <Combine
+        left={type === 'color' ? <Aws.Color size={size * 1.2} /> : <Aws size={size * 1.2} />}
+        right={<Bedrock.Combine size={size} type={type} />}
+        size={size}
+        {...props}
+      />
+    )),
+    Icon: Qwen, keywords: [ModelProvider.Qwen] },
   { Icon: Stepfun, combineMultiple: 0.83, keywords: [ModelProvider.Stepfun] },
   { Icon: Spark, combineMultiple: 0.92, keywords: [ModelProvider.Spark] },
   { Icon: Fireworks, combineMultiple: 1.14, keywords: [ModelProvider.FireworksAI] },

--- a/src/features/providerConfig.tsx
+++ b/src/features/providerConfig.tsx
@@ -169,7 +169,7 @@ export const providerMappings: ProviderMapping[] = [
         {...props}
       />
     )),
-    Icon: Qwen,
+    Icon: AlibabaCloud,
     combineMultiple: 1.1,
     keywords: [ModelProvider.Qwen],
   },


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

由于原本的 Qwen 被更改为 阿里云百炼，故同步替换 provider icon，并添加阿里云logo。

![image](https://github.com/user-attachments/assets/38acad20-9bd9-48e0-80ce-1ac5609fb62a)


#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
