### PR TITLE
💄 style: support v0 (Vercel) provider & model icons

### DIFF
--- a/src/features/modelConfig.ts
+++ b/src/features/modelConfig.ts
@@ -55,6 +55,7 @@ import Stepfun from '@/Stepfun';
 import Suno from '@/Suno';
 import Udio from '@/Udio';
 import Upstage from '@/Upstage';
+import V0 from '@/V0';
 import VertexAI from '@/VertexAI';
 import Voyage from '@/Voyage';
 import Wenxin from '@/Wenxin';
@@ -193,6 +194,7 @@ export const modelMappings: ModelMapping[] = [
   { Icon: Inflection, keywords: ['inflection-'] },
   { Icon: AionLabs, keywords: ['aion-'] },
   { Icon: AiHubMix, keywords: ['aihubmix'] },
+  { Icon: V0, keywords: ['^v0-'] },
   { Icon: VertexAI, keywords: ['^veo-', '/veo-'] },
   { Icon: Google, keywords: ['google'] },
 ];

--- a/src/features/providerConfig.tsx
+++ b/src/features/providerConfig.tsx
@@ -56,6 +56,8 @@ import Stepfun from '@/Stepfun';
 import TencentCloud from '@/TencentCloud';
 import Together from '@/Together';
 import Upstage from '@/Upstage';
+import V0 from '@/V0';
+import Vercel from '@/Vercel';
 import VertexAI from '@/VertexAI';
 import Vllm from '@/Vllm';
 import Volcengine from '@/Volcengine';
@@ -236,4 +238,17 @@ export const providerMappings: ProviderMapping[] = [
   { Icon: Xinference, combineMultiple: 0.85, keywords: [ModelProvider.Xinference] },
   { Icon: Fal, keywords: [ModelProvider.Fal] },
   { Icon: AiHubMix, combineMultiple: 0.9, keywords: [ModelProvider.AiHubMix] },
+  {
+    Combine: memo(({ size = 24, type = 'color', ...props }) => (
+      <Combine
+        left={<Vercel.Combine size={size * 1.1} type={type} />}
+        right={<V0.Combine size={size * 0.9} type={type} />}
+        size={size}
+        {...props}
+      />
+    )),
+    Icon: Vercel,
+    combineMultiple: 1.1,
+    keywords: [ModelProvider.V0],
+  },
 ];

--- a/src/features/providerConfig.tsx
+++ b/src/features/providerConfig.tsx
@@ -239,10 +239,10 @@ export const providerMappings: ProviderMapping[] = [
   { Icon: Fal, keywords: [ModelProvider.Fal] },
   { Icon: AiHubMix, combineMultiple: 0.9, keywords: [ModelProvider.AiHubMix] },
   {
-    Combine: memo(({ size = 24, type = 'color', ...props }) => (
+    Combine: memo(({ size = 24, ...props }) => (
       <Combine
-        left={<Vercel.Combine size={size * 1.1} type={type} />}
-        right={<V0.Combine size={size * 0.9} type={type} />}
+        left={<Vercel.Combine size={size * 1.1} />}
+        right={<V0 size={size * 0.9} />}
         size={size}
         {...props}
       />

--- a/src/features/providerConfig.tsx
+++ b/src/features/providerConfig.tsx
@@ -241,14 +241,13 @@ export const providerMappings: ProviderMapping[] = [
   {
     Combine: memo(({ size = 24, ...props }) => (
       <Combine
-        left={<Vercel.Combine size={size * 1.1} />}
-        right={<V0 size={size * 0.9} />}
+        left={<Vercel.Combine size={size * 0.9} />}
+        right={<V0 size={size} />}
         size={size}
         {...props}
       />
     )),
     Icon: Vercel,
-    combineMultiple: 1.1,
     keywords: [ModelProvider.V0],
   },
 ];

--- a/src/features/providerEnum.ts
+++ b/src/features/providerEnum.ts
@@ -49,6 +49,7 @@ export enum ModelProvider {
   TencentCloud = 'tencentcloud',
   TogetherAI = 'togetherai',
   Upstage = 'upstage',
+  V0 = 'v0',
   VLLM = 'vllm',
   VertexAI = 'vertexai',
   Volcengine = 'volcengine',


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [X] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

1. 增加对 v0 (Vercel) 供应商及模型图标的支持 https://github.com/lobehub/lobe-chat/pull/8235

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Add support for the new v0 (Vercel) provider and model icons

Enhancements:
- Add v0 entry to the provider enum
- Include v0 in the model icon mappings
- Configure combined Vercel+v0 icon in the provider mappings