### PR TITLE
✨ feat(model): improve some model icon matching rules

### DIFF
--- a/src/components/Dashboard/IconItem.tsx
+++ b/src/components/Dashboard/IconItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ActionIcon, Block, CopyButton } from '@lobehub/ui';
+import { ActionIcon, Block, CopyButton, Text } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
 import { Link } from 'dumi';
 import { DownloadIcon, SearchIcon } from 'lucide-react';
@@ -105,12 +105,9 @@ const IconItem = memo<IconItemProps>(({ children, title, color, id }) => {
         paddingInline={12}
         width={'100%'}
       >
-        <h2
-          className={styles.title}
-          style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
-        >
+        <Text as={'h2'} className={styles.title} ellipsis>
           {title}
-        </h2>
+        </Text>
         <CopyButton content={title} size={'small'} />
       </Flexbox>
       <Flexbox align={'center'} className={styles.row} horizontal>


### PR DESCRIPTION
- Fix DeepMind Imagen matching for 'fal-ai/imagen4/preview'
- Fix Qwen matching for 'wan2.2-t2i-flash' format models
- Fix TypeScript error: replace non-existent Text component with h2 element

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Fix various model mapping rules to properly recognize additional formats and resolve a TypeScript error by replacing a missing Text component with a styled h2 element

Bug Fixes:
- Extend model icon matching regex for DeepMind Imagen, Qwen 'wan2.2-t2i-flash', Doubao 'seedream'/ 'seededit', and Google 'nano-banana' formats
- Replace non-existent Text component with an h2 element and add overflow styling to fix a TypeScript error in IconItem