### PR TITLE
🐛 fix(rn): update to use expo-linear-gradient and improve gradient pa…

### DIFF
--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -58,17 +58,17 @@ pnpm add react-native-svg
 
 #### Optional: Gradient Support
 
-For gradient background support in Avatar components, install `react-native-linear-gradient`:
+For gradient background support in Avatar components, install `expo-linear-gradient`:
 
 ```bash
-npm install react-native-linear-gradient
+npm install expo-linear-gradient
 # or
-yarn add react-native-linear-gradient
+yarn add expo-linear-gradient
 # or
-pnpm add react-native-linear-gradient
+pnpm add expo-linear-gradient
 ```
 
-> 💡 **Note**: If `react-native-linear-gradient` is not installed, gradient backgrounds will automatically fallback to solid colors.
+> 💡 **Note**: If `expo-linear-gradient` is not installed, gradient backgrounds will automatically fallback to solid colors.
 
 ## 📖 Usage
 
@@ -152,17 +152,11 @@ import { Adobe } from '@lobehub/icons-rn';
 export default function App() {
   return (
     <View style={styles.container}>
-      {/* CSS gradient format - requires react-native-linear-gradient */}
-      <Adobe.Avatar 
-        size={48} 
-        background="linear-gradient(45deg, #9AD8F8, #3D8FFF, #6350FB)" 
-      />
-      
+      {/* CSS gradient format - requires expo-linear-gradient */}
+      <Adobe.Avatar size={48} background="linear-gradient(45deg, #9AD8F8, #3D8FFF, #6350FB)" />
+
       {/* Automatic fallback to solid color if gradient library not available */}
-      <Adobe.Avatar 
-        size={48} 
-        background="linear-gradient(to right, #FF6B35, #F7931E)" 
-      />
+      <Adobe.Avatar size={48} background="linear-gradient(to right, #FF6B35, #F7931E)" />
     </View>
   );
 }
@@ -194,12 +188,12 @@ export default function App() {
 
 ### Avatar Props
 
-| Prop           | Type     | Default     | Description                                                        |
-| -------------- | -------- | ----------- | ------------------------------------------------------------------ |
-| `size`         | `number` | `24`        | Avatar size in pixels                                              |
-| `background`   | `string` | Brand color | Background color or CSS gradient (e.g., `linear-gradient(...)`)   |
-| `color`        | `string` | `#FFFFFF`   | Icon color                                                         |
-| `iconMultiple` | `number` | `0.6`       | Icon size multiplier                                               |
+| Prop           | Type     | Default     | Description                                                     |
+| -------------- | -------- | ----------- | --------------------------------------------------------------- |
+| `size`         | `number` | `24`        | Avatar size in pixels                                           |
+| `background`   | `string` | Brand color | Background color or CSS gradient (e.g., `linear-gradient(...)`) |
+| `color`        | `string` | `#FFFFFF`   | Icon color                                                      |
+| `iconMultiple` | `number` | `0.6`       | Icon size multiplier                                            |
 
 ### Text Props
 
@@ -243,27 +237,12 @@ Avatar components support CSS `linear-gradient` format for rich visual effects:
 <Adobe.Avatar background="linear-gradient(to right, #FF6B35, #F7931E)" />
 <Adobe.Avatar background="linear-gradient(to bottom, #667eea, #764ba2)" />
 
-// Degree angles  
+// Degree angles
 <Adobe.Avatar background="linear-gradient(45deg, #9AD8F8, #3D8FFF, #6350FB)" />
 <Adobe.Avatar background="linear-gradient(135deg, #667eea, #764ba2)" />
 
 // Multiple colors with positions
 <Adobe.Avatar background="linear-gradient(90deg, #FF6B35 0%, #F7931E 50%, #C02425 100%)" />
-```
-
-### Automatic Fallback
-
-If `react-native-linear-gradient` is not installed or gradient parsing fails:
-
-- **Extracts first color** from gradient as solid background
-- **Graceful degradation** - no crashes or broken UI
-- **Development-friendly** - works without additional setup
-
-Example fallback behavior:
-```tsx
-// With library: Shows beautiful gradient
-// Without library: Shows solid #9AD8F8 background  
-<Adobe.Avatar background="linear-gradient(45deg, #9AD8F8, #3D8FFF, #6350FB)" />
 ```
 
 ## 📦 Available Icons

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -46,6 +46,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "expo-linear-gradient": "^14.1.5",
     "lodash-es": "^4.17.21"
   },
   "devDependencies": {
@@ -58,9 +59,9 @@
     "typescript": "^5.0.0"
   },
   "peerDependencies": {
+    "expo-linear-gradient": ">=14.1.5",
     "react": ">=16.8.0",
     "react-native": ">=0.76.9",
-    "react-native-linear-gradient": ">=2.8.0",
     "react-native-svg": ">=15.8.0"
   },
   "publishConfig": {

--- a/packages/react-native/tsup.config.ts
+++ b/packages/react-native/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   clean: true,
   dts: true,
   entry: ['src/index.ts'],
-  external: ['react', 'react-native', 'react-native-svg', 'react-native-linear-gradient'],
+  external: ['react', 'react-native', 'react-native-svg', 'expo-linear-gradient'],
   format: ['esm', 'cjs'],
   legacyOutput: true,
   minify: false,


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [x] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

  🐛 Bug Fixes

  React Native Package

  - Gradient Library Migration: Updated from react-native-linear-gradient to expo-linear-gradient for better compatibility and maintenance
    - Updated dependency from react-native-linear-gradient to expo-linear-gradient@^14.1.5
    - Improved gradient parsing logic with better type safety
    - Enhanced coordinate calculation for gradient directions
    - Fixed TypeScript types for gradient colors and locations arrays
    - Updated documentation and installation instructions
    - Maintained backward compatibility with automatic fallback to solid colors

  Breaking Changes:
  - Replaced react-native-linear-gradient peer dependency with expo-linear-gradient@>=14.1.5
  - Users need to install expo-linear-gradient instead of react-native-linear-gradient for gradient support


#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Migrate the React Native gradient support to use expo-linear-gradient and enhance gradient parsing logic, type safety, and documentation while preserving backward compatibility.

Bug Fixes:
- Fix TypeScript types for gradient colors and locations arrays

Enhancements:
- Migrate gradient rendering from react-native-linear-gradient to expo-linear-gradient and update tsup bundler externals
- Improve CSS linear-gradient parsing for better type safety, proper handling of color arrays and location percentages
- Enhance degree-to-coordinate conversion and default gradient direction logic
- Maintain fallback to a solid background color when the gradient library is not available

Build:
- Replace react-native-linear-gradient with expo-linear-gradient in dependencies, peerDependencies, and bundler externals

Documentation:
- Update README installation instructions and examples to reflect expo-linear-gradient usage