### PR TITLE
💄 style: Add cerebras provider

### DIFF
--- a/src/features/modelConfig.ts
+++ b/src/features/modelConfig.ts
@@ -150,7 +150,7 @@ export const modelMappings: ModelMapping[] = [
   { Icon: Gemma, keywords: ['gemma'] },
   { Icon: Moonshot, keywords: ['kimi', 'moonshot'] },
   { Icon: Qiniu, keywords: ['qiniu'] },
-  { Icon: Qwen, keywords: ['qwen', 'qwq', 'qvq', 'wanx', 'wan\\d/', 'wan\\d\\.\\d-'] },
+  { Icon: Qwen, keywords: ['qwen', 'qwq', 'qvq', 'wanx', 'wan\\d/', 'wan\\d\\.\\d-', 'tongyi'] },
   { Icon: Minimax, keywords: ['minimax', 'abab', '^image-'] },
   {
     Icon: Mistral,
@@ -184,7 +184,7 @@ export const modelMappings: ModelMapping[] = [
   { Icon: Doubao, keywords: ['^ep-', 'doubao-', 'seedream', 'seededit'] },
   { Icon: Hunyuan, keywords: ['hunyuan'] },
   { Icon: FishAudio, keywords: ['^d_', '^g_', '^wd_'] },
-  { Icon: ByteDance, keywords: ['skylark'] },
+  { Icon: ByteDance, keywords: ['skylark', 'seed-', 'bytedance'] },
   { Icon: BurnCloud, keywords: ['burncloud'] },
   {
     Icon: Stability,
@@ -202,7 +202,7 @@ export const modelMappings: ModelMapping[] = [
   },
   { Icon: Flux, keywords: ['flux'] },
   { Icon: Suno, keywords: ['suno'] },
-  { Icon: Microsoft, keywords: ['wizardlm', '/phi-', '^phi-', '-phi-'] },
+  { Icon: Microsoft, keywords: ['wizardlm', '/phi-', '^phi-', '-phi-', 'mai-', 'microsoft'] },
   { Icon: Adobe, keywords: ['firefly'] },
   { Icon: Ai21, keywords: ['jamba', '^j2-', 'ai21'] },
   { Icon: Upstage, keywords: ['^solar-', '/solar'] },

--- a/src/features/providerConfig.tsx
+++ b/src/features/providerConfig.tsx
@@ -17,6 +17,7 @@ import BaiduCloud from '@/BaiduCloud';
 import Bedrock from '@/Bedrock';
 import Bfl from '@/Bfl';
 import BurnCloud from '@/BurnCloud';
+import Cerebras from '@/Cerebras';
 import Claude from '@/Claude';
 import Cloudflare from '@/Cloudflare';
 import Cohere from '@/Cohere';
@@ -290,4 +291,5 @@ export const providerMappings: ProviderMapping[] = [
     keywords: [ModelProvider.OllamaCloud],
   },
   { Icon: LongCat, combineMultiple: 1, keywords: [ModelProvider.LongCat] },
+  { Icon: Cerebras, combineMultiple: 1, keywords: [ModelProvider.Cerebras] },
 ];

--- a/src/features/providerEnum.ts
+++ b/src/features/providerEnum.ts
@@ -11,6 +11,7 @@ export enum ModelProvider {
   Bedrock = 'bedrock',
   Bfl = 'bfl',
   BurnCloud = 'burncloud',
+  Cerebras = 'cerebras',
   Cloudflare = 'cloudflare',
   Cohere = 'cohere',
   CometAPI = 'cometapi',


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Add support for the Cerebras provider and refine model-to-icon keyword mappings.

New Features:
- Add Cerebras to the provider enum and provider mappings

Enhancements:
- Include 'tongyi' keyword for the Qwen model
- Add 'seed-' and 'bytedance' keywords for the ByteDance model
- Add 'mai-' and 'microsoft' keywords for the Microsoft model