### PR TITLE
✨ Add Replicate to provider config

### DIFF
--- a/src/features/providerConfig.tsx
+++ b/src/features/providerConfig.tsx
@@ -57,6 +57,7 @@ import Perplexity from '@/Perplexity';
 import Player2 from '@/Player2';
 import Qiniu from '@/Qiniu';
 import Qwen from '@/Qwen';
+import Replicate from '@/Replicate';
 import SambaNova from '@/SambaNova';
 import Search1API from '@/Search1API';
 import SenseNova from '@/SenseNova';
@@ -270,6 +271,7 @@ export const providerMappings: ProviderMapping[] = [
   },
   { Icon: Vercel, combineMultiple: 0.85, keywords: [ModelProvider.Vercel] },
   { Icon: Bfl, keywords: [ModelProvider.Bfl] },
+  { Icon: Replicate, combineMultiple: 0.9, keywords: [ModelProvider.Replicate] },
   { Icon: Nebius, combineMultiple: 0.75, keywords: [ModelProvider.Nebius] },
   { Icon: NewAPI, combineMultiple: 0.85, keywords: [ModelProvider.NewAPI] },
   { Icon: AkashChat, combineMultiple: 0.8, keywords: [ModelProvider.AkashChat] },

--- a/src/features/providerEnum.ts
+++ b/src/features/providerEnum.ts
@@ -50,6 +50,7 @@ export enum ModelProvider {
   Player2 = 'Player2',
   Qiniu = 'qiniu',
   Qwen = 'qwen',
+  Replicate = 'replicate',
   SambaNova = 'sambanova',
   Search1API = 'search1api',
   SenseNova = 'sensenova',


### PR DESCRIPTION
## Summary

Add Replicate provider icon mapping to enable proper icon display in LobeChat settings UI.

This PR adds the Replicate provider to:
- `providerEnum.ts` - Add `Replicate = 'replicate'` enum value
- `providerConfig.tsx` - Import Replicate icon and add mapping

## Related

This is needed for lobehub/lobe-chat#10426 which adds Replicate as an image generation provider.

## Test plan

- [ ] Verify Replicate icon displays correctly in provider settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add Replicate as a supported model provider and map it to its icon in the provider configuration.

New Features:
- Introduce Replicate as a new entry in the model provider enum.
- Add Replicate provider icon mapping to the provider configuration for use in the settings UI.