### PR TITLE
:sparkles: feat: add association for Nova icons

### DIFF
--- a/src/features/modelConfig.ts
+++ b/src/features/modelConfig.ts
@@ -81,7 +81,7 @@ import Yi from '@/Yi';
 import ZAI from '@/ZAI';
 import type { IconAvatarProps } from '@/features/IconAvatar';
 import type { IconCombineProps } from '@/features/IconCombine';
-import { Kwaipilot } from '@/icons';
+import { Kwaipilot, Nova } from '@/icons';
 import type { IconType } from '@/types';
 
 type ModelIconType = FC<IconType & any> & {
@@ -251,4 +251,5 @@ export const modelMappings: ModelMapping[] = [
   { Icon: Menlo, keywords: ['menlo', 'lucy', 'jan-nano'] },
   { Icon: LongCat, keywords: ['longcat'] },
   { Icon: Kwaipilot, keywords: ['kat-'] },
+  { Icon: Nova, keywords: ['^nova-', '/nova-'] },
 ];


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [X] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

This PR adds associations for Nova icons so Nova models tagged with nova- will be given the Nova (AWS) icons.

#### 📝 补充信息 | Additional Information

N/A

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

New Features:
- Associate Nova icon with models whose identifiers match nova- name patterns.