### PR TITLE
docs: add LiJian as contributor in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,6 +516,11 @@ $ bun start
 
 Contributions of all types are more than welcome, if you are interested in contributing code, feel free to check out our GitHub [Issues][github-issues-link] to get stuck in to show us what you’re made of.
 
+
+### ✨ Authors
+
+- **LiJian** - Contributor
+
 [![][pr-welcome-shield]][pr-welcome-link]
 
 [![][contributors-contrib]][contributors-link]


### PR DESCRIPTION
## Description

Add LiJian as a contributor in the README Contributing section.

## Changes

- Added Authors subsection under Contributing
- Listed LiJian as a contributor

---

🤖 This PR was created with assistance from LobeChat.

## Summary by Sourcery

Documentation:
- Document LiJian as a contributor in a new Authors subsection under the README contributing section.