### PR TITLE
✨ feat: add seedance keyword to Doubao model mapping

### DIFF
--- a/src/features/modelConfig.ts
+++ b/src/features/modelConfig.ts
@@ -228,7 +228,7 @@ export const modelMappings: ModelMapping[] = [
   { Icon: Rwkv, keywords: ['rwkv', '/eagle-'] },
   { Icon: Wenxin, keywords: ['ernie', 'irag'] },
   { Icon: Jina, keywords: ['^jina', '/jina'] },
-  { Icon: Doubao, keywords: ['^ep-', 'doubao-', 'seedream', 'seededit'] },
+  { Icon: Doubao, keywords: ['^ep-', 'doubao-', 'seedream', 'seededit', 'seedance-'] },
   { Icon: Hunyuan, keywords: ['hunyuan'] },
   { Icon: FishAudio, keywords: ['^d_', '^g_', '^wd_'] },
   { Icon: ByteDance, keywords: ['skylark', 'seed-', 'bytedance'] },


### PR DESCRIPTION
## Summary
- Add `seedance-` keyword to Doubao model mapping to support Seedance model identification

## Test plan
- [x] Type check passed
- [x] Lint passed
- [x] No circular dependencies

## Summary by Sourcery

New Features:
- Map Seedance-prefixed Doubao models to the Doubao icon via a new model keyword.