### PR TITLE
✨ feat: add glm-5 keywords to ZAI model mapping

### DIFF
--- a/src/features/modelConfig.ts
+++ b/src/features/modelConfig.ts
@@ -144,7 +144,7 @@ export const modelMappings: ModelMapping[] = [
     keywords: ['^gpt-', '/gpt-', 'openai'],
   },
   { Icon: GLMV, keywords: ['^glm-(.*)v', '/glm-(.*)v'] },
-  { Icon: ZAI, keywords: ['^glm-4', '/glm-4'] },
+  { Icon: ZAI, keywords: ['^glm-5', '/glm-5', '/glm5', '^glm-4', '/glm-4', '/glm4'] },
   { Icon: ChatGLM, keywords: ['^glm-', '/glm-', 'chatglm'] },
   { Icon: CodeGeeX, keywords: ['^codegeex', '/codegeex'] },
   { Icon: Claude, keywords: ['claude'] },


### PR DESCRIPTION
## Description

This PR updates the ZAI model mapping keywords to support NVIDIA NIM's GLM model ID format.

## Changes

- Added `^glm-5`, `/glm-5`, `/glm5` patterns for GLM-5 models
- Added `/glm4` pattern for GLM-4 models

## Related

NVIDIA NIM uses different model ID patterns for GLM series models (e.g., `/glm4`, `/glm5`), this change ensures proper icon mapping for these model IDs.