### PR TITLE
✨ feat: add OpenCodeGo and OpenCodeZen keyword mappings

### DIFF
--- a/src/features/agentConfig.ts
+++ b/src/features/agentConfig.ts
@@ -111,6 +111,8 @@ export const agentMappings: AgentMapping[] = [
   { Icon: Windsurf, keywords: ['windsurf'] },
   { Icon: Cline, keywords: ['cline'] },
   { Icon: OpenCode, keywords: ['open-code', 'opencode', 'openwork'] },
+  { Icon: OpenCode, keywords: ['open-code-go', 'opencodego'] },
+  { Icon: OpenCode, keywords: ['open-code-zen', 'opencodezen'] },
   { Icon: OpenHands, keywords: ['open-hands', 'openhands'] },
   { Icon: RooCode, keywords: ['roo-code', 'roocode'] },
   { Icon: Goose, keywords: ['goose'] },


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

Add keyword mappings in `agentConfig.ts` to reuse OpenCode icon for OpenCodeGo and OpenCodeZen plans.

- `open-code-go` / `opencodego` → OpenCode icon
- `open-code-zen` / `opencodezen` → OpenCode icon

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->