### PR TITLE
🐛 fix: Nano Banana 2 Lite model id not matching NanoBanana icon

### DIFF
--- a/packages/react-native/src/features/modelConfig.ts
+++ b/packages/react-native/src/features/modelConfig.ts
@@ -173,7 +173,7 @@ export const rnModelMappings: RNModelMapping[] = [
     keywords: [
       'gemini-3.1-flash-image-preview',
       'gemini-3-pro-image-preview',
-      'gemini-\\d+(?:\\.\\d+)?-(?:flash|pro)-image-preview$',
+      'gemini-\\d+(?:\\.\\d+)?-(?:flash(?:-lite)?|pro)-image(?:-preview)?',
       'nanobanana',
       'nano-banana',
     ],

--- a/packages/react-native/src/features/modelConfig.ts
+++ b/packages/react-native/src/features/modelConfig.ts
@@ -173,7 +173,7 @@ export const rnModelMappings: RNModelMapping[] = [
     keywords: [
       'gemini-3.1-flash-image-preview',
       'gemini-3-pro-image-preview',
-      'gemini-\\d+(?:\\.\\d+)?-(?:flash(?:-lite)?|pro)-image(?:-preview)?',
+      'gemini-\\d+(?:\\.\\d+)?-(?:flash(?:-lite)?|pro)-image(?:-preview)?(?::|$)',
       'nanobanana',
       'nano-banana',
     ],

--- a/src/features/modelConfig.ts
+++ b/src/features/modelConfig.ts
@@ -175,7 +175,7 @@ export const modelMappings: ModelMapping[] = [
     keywords: [
       'gemini-3.1-flash-image-preview',
       'gemini-3-pro-image-preview',
-      'gemini-\\d+(?:\\.\\d+)?-(?:flash|pro)-image-preview$',
+      'gemini-\\d+(?:\\.\\d+)?-(?:flash(?:-lite)?|pro)-image(?:-preview)?',
       'nanobanana',
       'nano-banana',
     ],

--- a/src/features/modelConfig.ts
+++ b/src/features/modelConfig.ts
@@ -175,7 +175,7 @@ export const modelMappings: ModelMapping[] = [
     keywords: [
       'gemini-3.1-flash-image-preview',
       'gemini-3-pro-image-preview',
-      'gemini-\\d+(?:\\.\\d+)?-(?:flash(?:-lite)?|pro)-image(?:-preview)?',
+      'gemini-\\d+(?:\\.\\d+)?-(?:flash(?:-lite)?|pro)-image(?:-preview)?(?::|$)',
       'nanobanana',
       'nano-banana',
     ],


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] 🐛 fix

#### 🔀 变更说明 | Description of Change

The `NanoBanana` icon matcher required `flash`/`pro` to be immediately followed by `-image-preview`, so the new `Nano Banana 2 Lite` model id `gemini-3.1-flash-lite-image:image` (with a `-lite-` infix and no `-preview` suffix) failed all keyword patterns and fell through to the generic `Gemini` icon instead.

Broadened the shared regex to accept an optional `-lite` suffix on `flash` and an optional `-preview` suffix on `-image`:

```diff
- gemini-\d+(?:\.\d+)?-(?:flash|pro)-image-preview$
+ gemini-\d+(?:\.\d+)?-(?:flash(?:-lite)?|pro)-image(?:-preview)?
```

#### 📝 补充信息 | Additional Information

Verified matches for `gemini-3.1-flash-lite-image:image`, `gemini-3.1-flash-image-preview`, and `gemini-3-pro-image-preview`, while `gemini-2.0-flash` still does not match.