### PR TITLE
fix(rn): support stroked (outline) icons in the web-to-RN converter

### DIFF
--- a/scripts/rn-conversion/utils/file-converter.ts
+++ b/scripts/rn-conversion/utils/file-converter.ts
@@ -45,8 +45,11 @@ export class FileConverter {
       content = this.removeWebSpecificImports(content);
 
       // 组件转换
+      // Stroked (outline) icons resolve their color through `stroke="currentColor"`
+      // rather than `fill="currentColor"`, so they also need the `color` prop.
       const hasCurrentColor = content.includes('fill="currentColor"');
-      content = this.updateComponentSignature(content, hasCurrentColor);
+      const hasStrokeColor = content.includes('stroke="currentColor"');
+      content = this.updateComponentSignature(content, hasCurrentColor || hasStrokeColor);
       content = this.convertSvgContent(content, hasCurrentColor);
 
       // 转换后更新导入（基于转换后的内容）
@@ -318,16 +321,25 @@ export class FileConverter {
 
   private formatSvgTag(content: string, hasCurrentColor: boolean): string {
     return content.replaceAll(/<Svg\s+([^>]*?)>/g, (match, attrs) => {
-      // 移除Web特有属性
-      let cleanAttrs = attrs.replaceAll(/\s*fill="[^"]*"/g, '').replaceAll(/\s*xmlns="[^"]*"/g, '');
+      // 描边图标通过 color 参数着色（与 fill="currentColor" 一致）
+      let workAttrs = attrs.replaceAll('stroke="currentColor"', 'stroke={color}');
+
+      // 移除Web特有的 fill，但保留 fill="none"（描边/轮廓图标需要它）
+      let cleanAttrs = workAttrs
+        .replaceAll(/\s*fill="(?!none")[^"]*"/g, '')
+        .replaceAll(/\s*xmlns="[^"]*"/g, '');
 
       // 构建属性数组
       const allAttrs = [];
       if (hasCurrentColor) allAttrs.push('color={color}');
 
-      // 按顺序添加属性
+      // 按顺序添加属性（保留 fill/stroke/strokeWidth，与根节点上的 fillRule 一样，
+      // 由子元素继承 —— react-native-svg 支持从 Svg 根节点继承呈现属性）
+      this.addAttributeIfExists(cleanAttrs, 'fill', allAttrs);
       this.addAttributeIfExists(cleanAttrs, 'fillRule', allAttrs);
       this.addAttributeIfExists(cleanAttrs, 'height', allAttrs);
+      this.addAttributeIfExists(cleanAttrs, 'stroke', allAttrs);
+      this.addAttributeIfExists(cleanAttrs, 'strokeWidth', allAttrs);
       this.addAttributeIfExists(cleanAttrs, 'style', allAttrs);
       this.addAttributeIfExists(cleanAttrs, 'viewBox', allAttrs);
       this.addAttributeIfExists(cleanAttrs, 'width', allAttrs);
@@ -361,8 +373,11 @@ export class FileConverter {
 
   private addAttributeIfExists(attrs: string, attrName: string, targetArray: string[]): void {
     const patterns = {
+      fill: /fill="[^"]*"|fill={[^}]+}/,
       fillRule: /fillRule="[^"]*"/,
       height: /height={[^}]+}/,
+      stroke: /stroke="[^"]*"|stroke={[^}]+}/,
+      strokeWidth: /strokeWidth={[^}]+}/,
       style: /style={[^}]+}/,
       viewBox: /viewBox="[^"]*"/,
       width: /width={[^}]+}/,

--- a/scripts/rn-conversion/utils/file-converter.ts
+++ b/scripts/rn-conversion/utils/file-converter.ts
@@ -223,6 +223,10 @@ export class FileConverter {
     result = this.formatSvgTag(result, hasCurrentColor);
     result = this.formatPathTag(result, hasCurrentColor);
 
+    // 子元素上的 stroke="currentColor" 也要转换（不只是根节点）：
+    // react-native-svg 不解析 CSS 的 currentColor，遗留下来会渲染成黑色。
+    result = result.replaceAll('stroke="currentColor"', 'stroke={color}');
+
     return result;
   }
 
@@ -377,7 +381,7 @@ export class FileConverter {
       fillRule: /fillRule="[^"]*"/,
       height: /height={[^}]+}/,
       stroke: /stroke="[^"]*"|stroke={[^}]+}/,
-      strokeWidth: /strokeWidth={[^}]+}/,
+      strokeWidth: /strokeWidth="[^"]*"|strokeWidth={[^}]+}/,
       style: /style={[^}]+}/,
       viewBox: /viewBox="[^"]*"/,
       width: /width={[^}]+}/,


### PR DESCRIPTION
## Problem

The web→React Native converter (`scripts/rn-conversion`) only handles **filled** icons. It keys off `fill="currentColor"`, strips every `fill="..."` from the `<Svg>` root, and has no handling for `stroke` / `strokeWidth`. So a **stroked (outline)** icon — `fill="none"` + `stroke="currentColor"` (or `stroke={CONSTANT}`) + `strokeWidth` on the root — loses all of that during conversion. In `react-native-svg`, shapes default to a black fill, so the generated RN icon renders as solid black blobs instead of the outline.

This surfaced on #343 (add Respira icon), the first purely stroked icon in the set — its generated RN `Mono`/`Color` came out as black circles.

## Fix

Handle stroked icons the same way the root `fillRule` is already preserved and inherited by children (`react-native-svg` inherits presentation props from the `<Svg>` root — the existing filled icons already rely on this for `fillRule`):

- add the `color` prop when `stroke="currentColor"` is present (parity with `fill="currentColor"`)
- convert `stroke="currentColor"` → `stroke={color}`
- keep `fill="none"`, `stroke`, and `strokeWidth` on the `<Svg>` root instead of dropping them

## Before → after (converter output for `Respira/Mono`)

```diff
  const Icon = memo<RNIconProps>(({ size = 24, style, color = '#000000', ...rest }) => {
    return (
      <Svg
+       fill="none"
        height={size}
+       stroke={color}
+       strokeWidth={1.7}
        style={style}
        viewBox="0 0 24 24"
        width={size}
        {...rest}
      >
        <Circle cx="12" cy="12" r="4" />
        ...
```

`Color` similarly keeps `stroke={COLOR_PRIMARY}`.

## Safety

Purely additive — the new branches only trigger when `fill="none"` / `stroke` are present. I diffed converter output **before vs after** this change across Adobe, OpenAI, Claude, Gemini, Mistral, Cohere, Ollama, Groq, Anthropic, Meta (Mono/Color/Text): **byte-identical**, no regression on filled icons.

## Note on #343

#343 currently hand-fixes the two Respira RN files (equivalently, via a `<G>` wrapper) so it can land independently. Regenerating Respira with this converter produces the flat `<Svg>`-root form shown above; happy to align #343 to the generated output if you'd prefer they match exactly.
