### PR TITLE
fix: add Manifest export to src/icons.ts

### DIFF
--- a/src/icons.ts
+++ b/src/icons.ts
@@ -189,6 +189,7 @@ export { default as Luma, type CompoundedIcon as LumaProps } from './Luma';
 export { default as Magic, type CompoundedIcon as MagicProps } from './Magic';
 export { default as Make, type CompoundedIcon as MakeProps } from './Make';
 export { default as Manus, type CompoundedIcon as ManusProps } from './Manus';
+export { default as Manifest, type CompoundedIcon as ManifestProps } from './Manifest';
 export { default as Mastra, type CompoundedIcon as MastraProps } from './Mastra';
 export { default as MCP, type CompoundedIcon as MCPProps } from './MCP';
 export { default as McpSo, type CompoundedIcon as McpSoProps } from './McpSo';


### PR DESCRIPTION
## Problem

PR #294 added the full `src/Manifest/` icon package but missed the export line in `src/icons.ts`, making the icon unreachable from the public API (`import { Manifest } from '@lobehub/icons'` would fail).

## Fix

Add the missing export line, placed alphabetically between `Manus` and `Mastra`:

```ts
export { default as Manifest, type CompoundedIcon as ManifestProps } from './Manifest';
```