### PR TITLE
✨ feat: add ChatGPT provider icon mapping

### DIFF
--- a/packages/react-native/src/features/providerConfig.tsx
+++ b/packages/react-native/src/features/providerConfig.tsx
@@ -265,7 +265,7 @@ export const rnProviderMappings: RNProviderMapping[] = [
     keywords: [RNModelProvider.Moonshot, RNModelProvider.KimiCodingPlan],
   },
   { Icon: Novita, keywords: [RNModelProvider.Novita] },
-  { Icon: OpenAI, keywords: [RNModelProvider.OpenAI] },
+  { Icon: OpenAI, keywords: [RNModelProvider.ChatGPT, RNModelProvider.OpenAI] },
   {
     Icon: OpenCode,
     keywords: [

--- a/packages/react-native/src/features/providerEnum.ts
+++ b/packages/react-native/src/features/providerEnum.ts
@@ -30,6 +30,7 @@ export enum RNModelProvider {
   ByteDance = 'bytedance',
   CentML = 'centml',
   Cerebras = 'cerebras',
+  ChatGPT = 'chatgpt',
   Civitai = 'civitai',
   Claude = 'claude',
   Cloudflare = 'cloudflare',

--- a/src/features/providerConfig.tsx
+++ b/src/features/providerConfig.tsx
@@ -269,7 +269,7 @@ export const providerMappings: ProviderMapping[] = [
     keywords: [ModelProvider.Moonshot, ModelProvider.KimiCodingPlan],
   },
   { Icon: Novita, keywords: [ModelProvider.Novita] },
-  { Icon: OpenAI, keywords: [ModelProvider.OpenAI] },
+  { Icon: OpenAI, keywords: [ModelProvider.ChatGPT, ModelProvider.OpenAI] },
   {
     Icon: OpenCode,
     keywords: [

--- a/src/features/providerEnum.ts
+++ b/src/features/providerEnum.ts
@@ -30,6 +30,7 @@ export enum ModelProvider {
   ByteDance = 'bytedance',
   CentML = 'centml',
   Cerebras = 'cerebras',
+  ChatGPT = 'chatgpt',
   Civitai = 'civitai',
   Claude = 'claude',
   Cloudflare = 'cloudflare',


### PR DESCRIPTION
## Summary

- add chatgpt to the provider enums
- map the ChatGPT provider ID to the existing OpenAI icon
- keep web and React Native provider mappings in sync

## Testing

- bunx --bun eslint --fix on changed files
- bunx --bun stylelint --fix on changed TSX files
- bun run type-check
- cd packages/react-native && bun run type-check
- bun run test --run (no test files found)