### PR TITLE
✨ feat: add Hunyuan icon mapping for Hy3 models

### DIFF
--- a/packages/react-native/src/features/modelConfig.ts
+++ b/packages/react-native/src/features/modelConfig.ts
@@ -247,7 +247,7 @@ export const rnModelMappings: RNModelMapping[] = [
   { Icon: Jimeng, keywords: ['^jimeng-', '/jimeng-', 'seedream', 'seededit', 'seedance-'] },
   { Icon: Doubao, keywords: ['^ep-', 'doubao-'] },
   { Icon: Kling, keywords: ['^kling', 'kling-', 'klingai'] },
-  { Icon: Hunyuan, keywords: ['hunyuan'] },
+  { Icon: Hunyuan, keywords: ['hunyuan', 'hy3'] },
   { Icon: FishAudio, keywords: ['^d_', '^g_', '^wd_'] },
   { Icon: ByteDance, keywords: ['skylark', 'seed-', 'bytedance'] },
   { Icon: BurnCloud, keywords: ['burncloud'] },

--- a/src/features/modelConfig.ts
+++ b/src/features/modelConfig.ts
@@ -249,7 +249,7 @@ export const modelMappings: ModelMapping[] = [
   { Icon: Jimeng, keywords: ['^jimeng-', '/jimeng-', 'seedream', 'seededit', 'seedance-'] },
   { Icon: Doubao, keywords: ['^ep-', 'doubao-'] },
   { Icon: Kling, keywords: ['^kling', 'kling-', 'klingai'] },
-  { Icon: Hunyuan, keywords: ['hunyuan'] },
+  { Icon: Hunyuan, keywords: ['hunyuan', 'hy3'] },
   { Icon: FishAudio, keywords: ['^d_', '^g_', '^wd_'] },
   { Icon: ByteDance, keywords: ['skylark', 'seed-', 'bytedance'] },
   { Icon: BurnCloud, keywords: ['burncloud'] },


### PR DESCRIPTION
## Summary

- map `hy3` and `hy3-preview` model IDs to the existing Hunyuan icon
- keep the web and React Native model mappings aligned

## Why

The existing Hunyuan mapping only recognizes model IDs containing `hunyuan`. Hy3 uses the shorter `hy3` naming, so both `hy3` and `hy3-preview` currently fall back to the default model icon even though they share the Hunyuan branding.

## Impact

Hy3 models now display the same Hunyuan logo as the previous Hunyuan generation across web and React Native consumers.

## Validation

- `bun run type-check`
- `bun run --cwd packages/react-native type-check`
- verified the `hy3` keyword matches both `hy3` and `hy3-preview`
