### PR TITLE
📝 docs: fix DeepAI website link

### DIFF
--- a/src/DeepAI/index.mdx
+++ b/src/DeepAI/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: DeepAI
-description: hhttps://deepai.org
+description: https://deepai.org
 category: Application
 ---
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] 📝 docs

#### 🔀 变更说明 | Description of Change

Fix the malformed DeepAI website URL in the page frontmatter.

#### 📝 补充信息 | Additional Information

Verified that `https://deepai.org` returns HTTP 200. `git diff --check` and the targeted spelling scan pass.
