### PR TITLE
🐛 fix: HappyHorse icon renders the title "Hedra"

### DIFF
--- a/src/HappyHorse/style.ts
+++ b/src/HappyHorse/style.ts
@@ -1,4 +1,4 @@
-export const TITLE = 'Hedra';
+export const TITLE = 'HappyHorse';
 export const COMBINE_TEXT_MULTIPLE = 0.8;
 export const COMBINE_SPACE_MULTIPLE = 0.2;
 export const COLOR_PRIMARY = '#000';

--- a/src/toc.json
+++ b/src/toc.json
@@ -2537,7 +2537,7 @@
       "hasTextCn": false,
       "hasTextColor": false
     },
-    "title": "Hedra"
+    "title": "HappyHorse"
   },
   {
     "color": "#000",


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

`src/HappyHorse/style.ts` exports `TITLE = 'Hedra'`. The icon package was scaffolded from `src/Hedra/` in #348 and this one constant was never renamed — the two files are otherwise byte-identical.

As a result every HappyHorse variant reports the wrong brand:

- `components/Mono.tsx`, `components/Text.tsx` → `<title>Hedra</title>`
- `components/Avatar.tsx`, `components/Combine.tsx` → `aria-label="Hedra"`

It also propagates to the docs site, because `scripts/tocWorkflow/index.ts#L58` derives `toc.json`'s `title` from `styleModule.TITLE`:

```jsonc
{
  "fullTitle": "HappyHorse",   // from index.mdx frontmatter — correct
  "id": "HappyHorse",
  "title": "Hedra"             // from style.ts — wrong, and this is what the card renders
}
```

So searching `happy` on https://icons.lobehub.com matches `HappyHorse` but renders a card labelled **Hedra** above the rocking-horse mark. The published static assets are affected too — `@lobehub/icons-static-svg@1.94.0` ships `icons/happyhorse.svg` and `icons/happyhorse-text.svg` with `<title>Hedra</title>` baked in.

This PR sets `TITLE = 'HappyHorse'` so it agrees with `fullTitle` in `src/HappyHorse/index.mdx`, and updates the one derived field in `src/toc.json`. Two lines, no artwork changes — the rocking horse is the correct mark for HappyHorse (快乐小马); `src/Hedra/` is a genuinely different icon and is untouched. The static SVG/PNG/WebP assets are left to the release workflow's `bun run build:static` auto-commit.

#### 📝 补充信息 | Additional Information

While tracking this down I scanned all 322 `src/*/style.ts` for duplicate `TITLE` values. Two more pairs look like the same scaffold copy-paste, and in both cases `style.ts` contradicts the icon's own `index.mdx` frontmatter:

| directory | `style.ts` `TITLE` | `index.mdx` `title` |
| --- | --- | --- |
| `src/Microsoft` | `Azure` | `Microsoft` |
| `src/XAI` | `Grok` | `xAI` |

I left them out to keep this PR reviewable, since both are long-standing and changing them would alter the `<title>` of already-published assets. Happy to fold them in here or open a follow-up — whichever you prefer.

> Disclosure: this change was AI-assisted (investigated and authored with Claude Code), reviewed by me before submitting.
