### PR TITLE
✨ feat: add Hunyuan icon mapping for Hy4 models

### DIFF
--- a/packages/react-native/src/features/modelConfig.ts
+++ b/packages/react-native/src/features/modelConfig.ts
@@ -247,7 +247,7 @@ export const rnModelMappings: RNModelMapping[] = [
   { Icon: Jimeng, keywords: ['^jimeng-', '/jimeng-', 'seedream', 'seededit', 'seedance-'] },
   { Icon: Doubao, keywords: ['^ep-', 'doubao-'] },
   { Icon: Kling, keywords: ['^kling', 'kling-', 'klingai'] },
-  { Icon: Hunyuan, keywords: ['hunyuan', 'hy3'] },
+  { Icon: Hunyuan, keywords: ['hunyuan', 'hy3', 'hy4'] },
   { Icon: FishAudio, keywords: ['^d_', '^g_', '^wd_'] },
   { Icon: ByteDance, keywords: ['skylark', 'seed-', 'bytedance'] },
   { Icon: BurnCloud, keywords: ['burncloud'] },

--- a/src/features/modelConfig.ts
+++ b/src/features/modelConfig.ts
@@ -249,7 +249,7 @@ export const modelMappings: ModelMapping[] = [
   { Icon: Jimeng, keywords: ['^jimeng-', '/jimeng-', 'seedream', 'seededit', 'seedance-'] },
   { Icon: Doubao, keywords: ['^ep-', 'doubao-'] },
   { Icon: Kling, keywords: ['^kling', 'kling-', 'klingai'] },
-  { Icon: Hunyuan, keywords: ['hunyuan', 'hy3'] },
+  { Icon: Hunyuan, keywords: ['hunyuan', 'hy3', 'hy4'] },
   { Icon: FishAudio, keywords: ['^d_', '^g_', '^wd_'] },
   { Icon: ByteDance, keywords: ['skylark', 'seed-', 'bytedance'] },
   { Icon: BurnCloud, keywords: ['burncloud'] },


### PR DESCRIPTION
## Summary

- map `hy4` and `hy4-preview` model IDs to the existing Hunyuan icon
- keep the web and React Native model mappings aligned

## Why

The Hunyuan mapping recognizes `hunyuan` and `hy3`, but Hy4 uses the shorter `hy4` model ID. As a result, `hy4` and `hy4-preview` fall back to the default icon even though they use the same Hunyuan branding.

## Impact

Hy4 models now display the Hunyuan logo across web and React Native consumers.

## Validation

- `bun run type-check` — passed
- Prettier check for both changed files — passed
- ESLint for both changed files — passed
- verified the `hy4` keyword matches both `hy4` and `hy4-preview`
- `bun run --cwd packages/react-native type-check` — changed file passed; the package still reports the unrelated existing `providerConfig.tsx:425` numeric `fontWeight` type error