### PR TITLE
🐛 fix: use Meta AI wordmark for the meta provider icon

### DIFF
--- a/packages/react-native/src/features/providerConfig.tsx
+++ b/packages/react-native/src/features/providerConfig.tsx
@@ -77,7 +77,7 @@ import LmStudio from '../icons/LmStudio';
 import LobeHub from '../icons/LobeHub';
 import LongCat from '../icons/LongCat';
 import Menlo from '../icons/Menlo';
-import Meta from '../icons/Meta';
+import MetaAI from '../icons/MetaAI';
 import Microsoft from '../icons/Microsoft';
 import Minimax from '../icons/Minimax';
 import Mistral from '../icons/Mistral';
@@ -189,7 +189,7 @@ export const rnProviderMappings: RNProviderMapping[] = [
   { Icon: LlmApi, keywords: [RNModelProvider.LlmApi] },
   { Icon: LG, keywords: [RNModelProvider.LG] },
   { Icon: Menlo, keywords: [RNModelProvider.Menlo] },
-  { Icon: Meta, keywords: [RNModelProvider.Meta] },
+  { Icon: MetaAI, keywords: [RNModelProvider.Meta] },
   { Icon: Microsoft, keywords: [RNModelProvider.Microsoft] },
   { Icon: NPLCloud, keywords: [RNModelProvider.NPLCloud] },
   { Icon: NousResearch, keywords: [RNModelProvider.NousResearch] },

--- a/src/features/providerConfig.tsx
+++ b/src/features/providerConfig.tsx
@@ -78,7 +78,7 @@ import LmStudio from '@/LmStudio';
 import LobeHub from '@/LobeHub';
 import LongCat from '@/LongCat';
 import Menlo from '@/Menlo';
-import Meta from '@/Meta';
+import MetaAI from '@/MetaAI';
 import Microsoft from '@/Microsoft';
 import Minimax from '@/Minimax';
 import Mistral from '@/Mistral';
@@ -193,7 +193,7 @@ export const providerMappings: ProviderMapping[] = [
   { Icon: LlmApi, keywords: [ModelProvider.LlmApi] },
   { Icon: LG, keywords: [ModelProvider.LG] },
   { Icon: Menlo, keywords: [ModelProvider.Menlo] },
-  { Icon: Meta, keywords: [ModelProvider.Meta] },
+  { Icon: MetaAI, keywords: [ModelProvider.Meta] },
   { Icon: Microsoft, keywords: [ModelProvider.Microsoft] },
   { Icon: NPLCloud, keywords: [ModelProvider.NPLCloud] },
   { Icon: NousResearch, keywords: [ModelProvider.NousResearch] },


### PR DESCRIPTION
## What

`providerMappings` points the `meta` provider at the `Meta` icon, whose `Combine` / `Text` components render the **Llama** wordmark (`viewBox="0 0 75 24"`). This PR points it at the existing `MetaAI` icon, which renders the **Meta AI** wordmark (`viewBox="0 0 101 24"`).

## Why

LobeHub's Meta provider now serves Meta's own hosted models (Muse Spark) rather than Llama weights, so the provider settings page shows a "Llama" lockup while the same `<svg>`'s `<title>` says `Meta` — the sidebar label and the brand lockup disagree.

Rendering `Meta/components/Text` and `MetaAI/components/Text` side by side confirms which is which:

| mapping                    | rendered wordmark |
| -------------------------- | ----------------- |
| `Meta` (current)           | `Llama`           |
| `MetaAI` (this PR)         | `Meta AI`         |

`agentConfig.ts` already maps `meta-ai` / `metaai` to `MetaAI`, so this makes the provider mapping consistent with it.

## Scope

- Llama **models** keep the `Meta` icon — `modelConfig.ts` (`{ Icon: Meta, keywords: ['llama', '/l3'] }`) is untouched in both packages.
- Both the main package and the react-native package are updated.
- No enum change needed; `ModelProvider.Meta` already exists.

## Verification

- `bun run type-check` (root) — clean apart from a pre-existing, unrelated `src/components/Editor/svgo.ts: Cannot find module 'svgo/browser'`.
- `cd packages/react-native && bun run type-check` — clean.
- `grep -rn "MetaAI" src/features packages/react-native/src/features` — hits in both config files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)