### PR TITLE
🐛 fix: remove committed docs-kit generated react-router config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ test-output
 
 # docs
 .react-router
+react-router.config.mjs
 
 # husky
 .husky/prepare-commit-msg

--- a/react-router.config.mjs
+++ b/react-router.config.mjs
@@ -1,3 +1,0 @@
-// @lobehub/docs-kit generated react-router config
-// This file is managed by `lobedocs` and is removed when the command exits.
-export { default } from "file:///home/i/lobe-icons/node_modules/.pnpm/@lobehub+docs-kit@5.27.0_3847cf38dfeac6101d12beaf28422c1b/node_modules/@lobehub/docs-kit/site/react-router.config.ts";


### PR DESCRIPTION
## Problem

Every PR's **Test CI** and **Pkg Pr New CI** fail at the `Install deps` step:

```
Error loading /home/runner/work/lobe-icons/lobe-icons/react-router.config.mjs:
Failed to load url /home/i/lobe-icons/node_modules/.pnpm/@lobehub+docs-kit@5.27.0_.../site/react-router.config.ts
error: prepare script from "@lobehub/icons" exited with 1
```

`react-router.config.mjs` is a temporary file that `lobedocs` generates (with a machine-local absolute path) and removes when the command exits. It was accidentally committed in 4aaf4ee1, so `bun install` → `prepare` → `lobedocs typegen` now loads the stale file and fails on CI.

## Fix

- Delete the committed `react-router.config.mjs`
- Add it to `.gitignore` next to `.react-router` so it can't be committed again

Verified locally: `bun run setup` succeeds and leaves no file behind.

Unblocks #403 and any other open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)