### PR TITLE
🐛 fix: stop the workspace glob from descending into nested node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "workspaces": [
     "*",
-    "packages/**"
+    "packages/*"
   ],
   "scripts": {
     "auto-converter-web-icons-to-rn": "bun scripts/rn-conversion/auto-converter.ts --lint",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 packages:
   - '*'
-  - 'packages/**'
+  - 'packages/*'
 allowBuilds:
   core-js: true
   core-js-pure: true


### PR DESCRIPTION
## Problem

Since 2026-08-12 every Release CI run on master fails at **Release Static** (the `@lobehub/icons-rn` and `@lobehub/icons-static-*` publish), e.g. [run 33973940146](https://github.com/lobehub/lobe-icons/actions/runs/33973940146):

```
msr: [multi-semantic-release]: Error: Duplicated pkg names: ,
```

`multi-semantic-release` discovers workspace packages via `@semrel-extra/topo`, which globs `<workspace>/package.json` with fast-glob and **no node_modules exclusion**. The `packages/**` pattern therefore descends into `packages/react-native/node_modules/` and picks up dependency manifests. Reproduced locally with the same patterns:

| pattern | matched | without `name` |
| --- | --- | --- |
| `packages/**` | 18 | 3 (`react-native-svg/css`, `react-native-svg/filter-image`, `tsup/assets`) |
| `packages/*` | 5 | 0 |

Multiple empty names are treated as duplicates, and the step aborts before publishing. The repo has no lockfile, so the dependency re-resolution in mid-August is what started surfacing these files.

## Fix

Use `packages/*` in both `package.json#workspaces` and `pnpm-workspace.yaml`. There are no nested packages under `packages/`, so the real workspaces are unchanged.

After merge, the next Release CI should publish the RN and static packages that have been queued since July.

🤖 Generated with [Claude Code](https://claude.com/claude-code)