### PR TITLE
🐛 fix: use Meta infinity icon for Muse Spark models

### DIFF
--- a/packages/react-native/src/features/modelConfig.ts
+++ b/packages/react-native/src/features/modelConfig.ts
@@ -58,7 +58,6 @@ import Liquid from '../icons/Liquid';
 import LongCat from '../icons/LongCat';
 import Menlo from '../icons/Menlo';
 import Meta from '../icons/Meta';
-import MetaAI from '../icons/MetaAI';
 import Microsoft from '../icons/Microsoft';
 import Minimax from '../icons/Minimax';
 import Mistral from '../icons/Mistral';
@@ -280,7 +279,7 @@ export const rnModelMappings: RNModelMapping[] = [
   { Icon: Grok, keywords: ['^grok-', '/grok-'] },
   { Icon: Ideogram, keywords: ['ideogram', '^v_1', '^v_2', '^v3$', '^upscale$', '^describe$'] },
   /** Match Muse Spark before the broad iFlyTek Spark keyword. */
-  { Icon: MetaAI, keywords: ['(^|/)muse-spark($|-)'] },
+  { Icon: Meta, keywords: ['(^|/)muse-spark($|-)'] },
   {
     Icon: Spark,
     keywords: [

--- a/packages/react-native/src/features/modelConfig.ts
+++ b/packages/react-native/src/features/modelConfig.ts
@@ -58,6 +58,7 @@ import Liquid from '../icons/Liquid';
 import LongCat from '../icons/LongCat';
 import Menlo from '../icons/Menlo';
 import Meta from '../icons/Meta';
+import MetaAI from '../icons/MetaAI';
 import Microsoft from '../icons/Microsoft';
 import Minimax from '../icons/Minimax';
 import Mistral from '../icons/Mistral';
@@ -278,6 +279,8 @@ export const rnModelMappings: RNModelMapping[] = [
   { Icon: SenseNova, keywords: ['SenseChat', 'SenseNova'] },
   { Icon: Grok, keywords: ['^grok-', '/grok-'] },
   { Icon: Ideogram, keywords: ['ideogram', '^v_1', '^v_2', '^v3$', '^upscale$', '^describe$'] },
+  /** Match Muse Spark before the broad iFlyTek Spark keyword. */
+  { Icon: MetaAI, keywords: ['(^|/)muse-spark($|-)'] },
   {
     Icon: Spark,
     keywords: [

--- a/src/features/modelConfig.ts
+++ b/src/features/modelConfig.ts
@@ -58,7 +58,6 @@ import Liquid from '@/Liquid';
 import LongCat from '@/LongCat';
 import Menlo from '@/Menlo';
 import Meta from '@/Meta';
-import MetaAI from '@/MetaAI';
 import Microsoft from '@/Microsoft';
 import Minimax from '@/Minimax';
 import Mistral from '@/Mistral';
@@ -282,7 +281,7 @@ export const modelMappings: ModelMapping[] = [
   { Icon: Grok, keywords: ['^grok-', '/grok-'] },
   { Icon: Ideogram, keywords: ['ideogram', '^v_1', '^v_2', '^v3$', '^upscale$', '^describe$'] },
   /** Match Muse Spark before the broad iFlyTek Spark keyword. */
-  { Icon: MetaAI, keywords: ['(^|/)muse-spark($|-)'] },
+  { Icon: Meta, keywords: ['(^|/)muse-spark($|-)'] },
   {
     Icon: Spark,
     keywords: [

--- a/src/features/modelConfig.ts
+++ b/src/features/modelConfig.ts
@@ -58,6 +58,7 @@ import Liquid from '@/Liquid';
 import LongCat from '@/LongCat';
 import Menlo from '@/Menlo';
 import Meta from '@/Meta';
+import MetaAI from '@/MetaAI';
 import Microsoft from '@/Microsoft';
 import Minimax from '@/Minimax';
 import Mistral from '@/Mistral';
@@ -280,6 +281,8 @@ export const modelMappings: ModelMapping[] = [
   { Icon: SenseNova, keywords: ['SenseChat', 'SenseNova'] },
   { Icon: Grok, keywords: ['^grok-', '/grok-'] },
   { Icon: Ideogram, keywords: ['ideogram', '^v_1', '^v_2', '^v3$', '^upscale$', '^describe$'] },
+  /** Match Muse Spark before the broad iFlyTek Spark keyword. */
+  { Icon: MetaAI, keywords: ['(^|/)muse-spark($|-)'] },
   {
     Icon: Spark,
     keywords: [

--- a/tests/ModelIcon.test.tsx
+++ b/tests/ModelIcon.test.tsx
@@ -1,19 +1,29 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
+import MetaColor from '../src/Meta/components/Color';
 import ModelIcon from '../src/features/ModelIcon';
 
 describe('ModelIcon brand resolution', () => {
+  it('renders the Meta color icon for Muse Spark', () => {
+    const markup = renderToStaticMarkup(
+      <ModelIcon model={'muse-spark-1.3'} size={32} type={'color'} />,
+    );
+
+    expect(markup).toBe(renderToStaticMarkup(<MetaColor size={32} />));
+  });
+
   it.each([
     'muse-spark-1.3',
     'muse-spark',
     'meta/muse-spark-1.3',
     'aihubmix/muse-spark-1.3',
     'Muse-Spark-1.3',
-  ])('uses Meta AI for %s instead of iFlyTek Spark', (model) => {
+  ])('uses Meta for %s instead of iFlyTek Spark', (model) => {
     const markup = renderToStaticMarkup(<ModelIcon model={model} type={'mono'} />);
 
-    expect(markup).toContain('<title>MetaAI</title>');
+    expect(markup).toContain('<title>Meta</title>');
+    expect(markup).not.toContain('<title>MetaAI</title>');
     expect(markup).not.toContain('<title>Spark</title>');
   });
 

--- a/tests/ModelIcon.test.tsx
+++ b/tests/ModelIcon.test.tsx
@@ -1,0 +1,36 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import ModelIcon from '../src/features/ModelIcon';
+
+describe('ModelIcon brand resolution', () => {
+  it.each([
+    'muse-spark-1.3',
+    'muse-spark',
+    'meta/muse-spark-1.3',
+    'aihubmix/muse-spark-1.3',
+    'Muse-Spark-1.3',
+  ])('uses Meta AI for %s instead of iFlyTek Spark', (model) => {
+    const markup = renderToStaticMarkup(<ModelIcon model={model} type={'mono'} />);
+
+    expect(markup).toContain('<title>MetaAI</title>');
+    expect(markup).not.toContain('<title>Spark</title>');
+  });
+
+  it.each(['spark', 'spark-v3.5', 'generalv3.5', '4.0ultra'])(
+    'preserves the iFlyTek Spark icon for %s',
+    (model) => {
+      const markup = renderToStaticMarkup(<ModelIcon model={model} type={'mono'} />);
+
+      expect(markup).toContain('<title>Spark</title>');
+    },
+  );
+
+  it('preserves the Meta icon for Llama models', () => {
+    const markup = renderToStaticMarkup(
+      <ModelIcon model={'meta-llama/llama-3.3-70b'} type={'mono'} />,
+    );
+
+    expect(markup).toContain('<title>Meta</title>');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
 import { name } from './package.json';
@@ -5,10 +6,16 @@ import { name } from './package.json';
 export default defineConfig({
   test: {
     alias: {
-      '@': './src',
-      [name]: './src',
+      '@': fileURLToPath(new URL('src', import.meta.url)),
+      [name]: fileURLToPath(new URL('src', import.meta.url)),
     },
     environment: 'jsdom',
     globals: true,
+    server: {
+      deps: {
+        /** Transform LobeHub packages that use directory imports in their ESM output. */
+        inline: [/@lobehub\//],
+      },
+    },
   },
 });


### PR DESCRIPTION
#### Change Type

- [x] 🐛 fix

#### Description of Change

Muse Spark model IDs such as `muse-spark-1.3` currently match the generic `spark` keyword and display the iFlyTek Spark icon. Add a more specific Muse Spark mapping before that rule in both the web and React Native packages.

Use the existing **Meta infinity icon**, including its blue color variant. Preserve the existing Meta AI provider mapping and the Spark and Llama model mappings.

#### Additional Information

- Add 11 component-rendering regression tests covering Muse Spark IDs, provider prefixes, case-insensitive matching, the exact Meta color icon, and existing Spark/Llama behavior.
- Fix the Vitest source aliases and inline LobeHub ESM dependencies so component tests can load.
- Validation: regression tests, targeted ESLint, and React Native type-check pass. The web type-check reports `src/components/Editor/svgo.ts:1` cannot resolve `svgo/browser`; the same error reproduces in the original checkout without this change.
