### PR TITLE
✨ feat: add The Grid icon

### DIFF
--- a/packages/react-native/src/features/providerConfig.tsx
+++ b/packages/react-native/src/features/providerConfig.tsx
@@ -118,6 +118,7 @@ import TII from '../icons/TII';
 import Targon from '../icons/Targon';
 import Tencent from '../icons/Tencent';
 import TencentCloud from '../icons/TencentCloud';
+import TheGrid from '../icons/TheGrid';
 import Together from '../icons/Together';
 import Upstage from '../icons/Upstage';
 import V0 from '../icons/V0';
@@ -394,6 +395,7 @@ export const rnProviderMappings: RNProviderMapping[] = [
   { Icon: Ai302, combineMultiple: 0.9, keywords: [RNModelProvider.Ai302] },
   { Icon: AiHubMix, combineMultiple: 0.9, keywords: [RNModelProvider.AiHubMix] },
   { Icon: CometAPI, keywords: [RNModelProvider.CometAPI] },
+  { Icon: TheGrid, keywords: [RNModelProvider.TheGrid] },
   {
     Combine: memo(({ size = 24, ...props }) => (
       <Combine

--- a/packages/react-native/src/features/providerEnum.ts
+++ b/packages/react-native/src/features/providerEnum.ts
@@ -130,6 +130,7 @@ export enum RNModelProvider {
   Targon = 'targon',
   Tencent = 'tencent',
   TencentCloud = 'tencentcloud',
+  TheGrid = 'thegrid',
   TogetherAI = 'togetherai',
   Upstage = 'upstage',
   V0 = 'v0',

--- a/packages/react-native/src/icons/TheGrid/components/Avatar.tsx
+++ b/packages/react-native/src/icons/TheGrid/components/Avatar.tsx
@@ -1,0 +1,22 @@
+import React, { memo } from 'react';
+
+import { RNIconAvatar, type RNIconAvatarProps } from '@/features';
+
+import { AVATAR_BACKGROUND, AVATAR_COLOR, AVATAR_ICON_MULTIPLE, TITLE } from '../style';
+import Mono from './Mono';
+
+export type AvatarProps = Omit<RNIconAvatarProps, 'Icon'>;
+
+const Avatar = memo<AvatarProps>(({ background, ...rest }) => {
+  return (
+    <RNIconAvatar
+      Icon={Mono}
+      aria-label={TITLE}
+      background={background || AVATAR_BACKGROUND}
+      color={AVATAR_COLOR}
+      iconMultiple={AVATAR_ICON_MULTIPLE}
+      {...rest}
+    />
+  );
+});
+export default Avatar;

--- a/packages/react-native/src/icons/TheGrid/components/Mono.tsx
+++ b/packages/react-native/src/icons/TheGrid/components/Mono.tsx
@@ -1,0 +1,35 @@
+import React, { memo } from 'react';
+import { Path, Svg } from 'react-native-svg';
+
+import type { RNIconProps } from '@/features';
+
+const Icon = memo<RNIconProps>(({ size = 24, style, color = '#000000', ...rest }) => {
+  return (
+    <Svg
+      color={color}
+      fillRule="evenodd"
+      height={size}
+      style={style}
+      viewBox="0 0 24 24"
+      width={size}
+      {...rest}
+    >
+      <Path d="M4 3L7.76471 6.40541V8.35135H4V3Z" fill={color} />
+      <Path d="M4 21L7.76471 17.5946V15.6486H4V21Z" fill={color} />
+      <Path d="M20 3L16.2353 6.40541V8.35135H20V3Z" fill={color} />
+      <Path d="M20 21L16.2353 17.5946V15.6486H20V21Z" fill={color} />
+      <Path d="M9.17642 3L11.0588 6.40542V8.35135H9.17642V3Z" fill={color} />
+      <Path d="M9.17642 21L11.0588 17.5946V15.6486H9.17642V21Z" fill={color} />
+      <Path d="M14.8236 3L12.9412 6.40542V8.35135H14.8236V3Z" fill={color} />
+      <Path d="M14.8236 21L12.9412 17.5946V15.6486H14.8236V21Z" fill={color} />
+      <Path d="M4 8.59458L7.7647 10.5405V13.4594L4 15.4054V8.59458Z" fill={color} />
+      <Path d="M9.17642 8.59457L11.0588 10.5405V13.4594L9.17642 15.4054V8.59457Z" fill={color} />
+      <Path d="M14.8236 8.59457L12.9412 10.5405V13.4594L14.8236 15.4054V8.59457Z" fill={color} />
+      <Path d="M20 8.59458L16.2353 10.5405V13.4594L20 15.4054V8.59458Z" fill={color} />
+    </Svg>
+  );
+});
+
+Icon.displayName = 'TheGridMono';
+
+export default Icon;

--- a/packages/react-native/src/icons/TheGrid/index.ts
+++ b/packages/react-native/src/icons/TheGrid/index.ts
@@ -1,0 +1,15 @@
+import Avatar from './components/Avatar';
+import Mono from './components/Mono';
+import { COLOR_PRIMARY, TITLE } from './style';
+
+export type CompoundedIcon = typeof Mono & {
+  Avatar: typeof Avatar;
+  colorPrimary: string;
+  title: string;
+};
+
+const Icons = Mono as CompoundedIcon;
+Icons.Avatar = Avatar;
+Icons.colorPrimary = COLOR_PRIMARY;
+Icons.title = TITLE;
+export default Icons;

--- a/packages/react-native/src/icons/TheGrid/style.ts
+++ b/packages/react-native/src/icons/TheGrid/style.ts
@@ -1,0 +1,7 @@
+export const TITLE = 'The Grid';
+export const COLOR_PRIMARY = '#0049E6';
+
+// Avatar constants
+export const AVATAR_BACKGROUND = COLOR_PRIMARY;
+export const AVATAR_COLOR = '#fff';
+export const AVATAR_ICON_MULTIPLE = 0.7;

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -353,6 +353,7 @@ export {
   default as TencentCloud,
   type CompoundedIcon as TencentCloudProps,
 } from './icons/TencentCloud';
+export { default as TheGrid, type CompoundedIcon as TheGridProps } from './icons/TheGrid';
 export { default as Tiangong, type CompoundedIcon as TiangongProps } from './icons/Tiangong';
 export { default as TII, type CompoundedIcon as TIIProps } from './icons/TII';
 export { default as Together, type CompoundedIcon as TogetherProps } from './icons/Together';

--- a/src/TheGrid/components/Avatar.tsx
+++ b/src/TheGrid/components/Avatar.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { memo } from 'react';
+
+import IconAvatar, { type IconAvatarProps } from '@/features/IconAvatar';
+
+import { AVATAR_BACKGROUND, AVATAR_COLOR, AVATAR_ICON_MULTIPLE, TITLE } from '../style';
+import Mono from './Mono';
+
+export type AvatarProps = Omit<IconAvatarProps, 'Icon'>;
+
+const Avatar = memo<AvatarProps>(({ ...rest }) => {
+  return (
+    <IconAvatar
+      Icon={Mono}
+      aria-label={TITLE}
+      background={AVATAR_BACKGROUND}
+      color={AVATAR_COLOR}
+      iconMultiple={AVATAR_ICON_MULTIPLE}
+      {...rest}
+    />
+  );
+});
+
+export default Avatar;

--- a/src/TheGrid/components/Color.tsx
+++ b/src/TheGrid/components/Color.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { memo } from 'react';
+
+import type { IconType } from '@/types';
+
+import { COLOR_PRIMARY, TITLE } from '../style';
+
+const Icon: IconType = memo(({ size = '1em', style, ...rest }) => {
+  return (
+    <svg
+      fillRule="evenodd"
+      height={size}
+      style={{ flex: 'none', lineHeight: 1, ...style }}
+      viewBox="0 0 24 24"
+      width={size}
+      xmlns="http://www.w3.org/2000/svg"
+      {...rest}
+    >
+      <title>{TITLE}</title>
+      <path d="M4 3L7.76471 6.40541V8.35135H4V3Z" fill={COLOR_PRIMARY} />
+      <path d="M4 21L7.76471 17.5946V15.6486H4V21Z" fill={COLOR_PRIMARY} />
+      <path d="M20 3L16.2353 6.40541V8.35135H20V3Z" fill={COLOR_PRIMARY} />
+      <path d="M20 21L16.2353 17.5946V15.6486H20V21Z" fill={COLOR_PRIMARY} />
+      <path d="M9.17642 3L11.0588 6.40542V8.35135H9.17642V3Z" fill={COLOR_PRIMARY} />
+      <path d="M9.17642 21L11.0588 17.5946V15.6486H9.17642V21Z" fill={COLOR_PRIMARY} />
+      <path d="M14.8236 3L12.9412 6.40542V8.35135H14.8236V3Z" fill={COLOR_PRIMARY} />
+      <path d="M14.8236 21L12.9412 17.5946V15.6486H14.8236V21Z" fill={COLOR_PRIMARY} />
+      <path d="M4 8.59458L7.7647 10.5405V13.4594L4 15.4054V8.59458Z" fill={COLOR_PRIMARY} />
+      <path d="M9.17642 8.59457L11.0588 10.5405V13.4594L9.17642 15.4054V8.59457Z" fill={COLOR_PRIMARY} />
+      <path d="M14.8236 8.59457L12.9412 10.5405V13.4594L14.8236 15.4054V8.59457Z" fill={COLOR_PRIMARY} />
+      <path d="M20 8.59458L16.2353 10.5405V13.4594L20 15.4054V8.59458Z" fill={COLOR_PRIMARY} />
+    </svg>
+  );
+});
+
+export default Icon;

--- a/src/TheGrid/components/Mono.tsx
+++ b/src/TheGrid/components/Mono.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { memo } from 'react';
+
+import type { IconType } from '@/types';
+
+import { TITLE } from '../style';
+
+const Icon: IconType = memo(({ size = '1em', style, ...rest }) => {
+  return (
+    <svg
+      fill="currentColor"
+      fillRule="evenodd"
+      height={size}
+      style={{ flex: 'none', lineHeight: 1, ...style }}
+      viewBox="0 0 24 24"
+      width={size}
+      xmlns="http://www.w3.org/2000/svg"
+      {...rest}
+    >
+      <title>{TITLE}</title>
+      <path d="M4 3L7.76471 6.40541V8.35135H4V3Z" />
+      <path d="M4 21L7.76471 17.5946V15.6486H4V21Z" />
+      <path d="M20 3L16.2353 6.40541V8.35135H20V3Z" />
+      <path d="M20 21L16.2353 17.5946V15.6486H20V21Z" />
+      <path d="M9.17642 3L11.0588 6.40542V8.35135H9.17642V3Z" />
+      <path d="M9.17642 21L11.0588 17.5946V15.6486H9.17642V21Z" />
+      <path d="M14.8236 3L12.9412 6.40542V8.35135H14.8236V3Z" />
+      <path d="M14.8236 21L12.9412 17.5946V15.6486H14.8236V21Z" />
+      <path d="M4 8.59458L7.7647 10.5405V13.4594L4 15.4054V8.59458Z" />
+      <path d="M9.17642 8.59457L11.0588 10.5405V13.4594L9.17642 15.4054V8.59457Z" />
+      <path d="M14.8236 8.59457L12.9412 10.5405V13.4594L14.8236 15.4054V8.59457Z" />
+      <path d="M20 8.59458L16.2353 10.5405V13.4594L20 15.4054V8.59458Z" />
+    </svg>
+  );
+});
+
+export default Icon;

--- a/src/TheGrid/index.mdx
+++ b/src/TheGrid/index.mdx
@@ -1,0 +1,46 @@
+---
+title: The Grid
+description: https://thegrid.ai
+category: Provider
+---
+
+import { TheGrid } from '@lobehub/icons';
+import { Flexbox } from '@lobehub/ui';
+
+import ColorPreview from '../components/ColorPreview';
+import DocsPreview from '../components/DocsPreview';
+
+## Icons
+
+<DocsPreview>{<TheGrid size={64} />}</DocsPreview>
+
+```tsx
+import { TheGrid } from '@lobehub/icons';
+
+export default () => <TheGrid size={64} />;
+```
+
+## Color
+
+<ColorPreview color={TheGrid.colorPrimary} />
+
+```tsx
+import { TheGrid } from '@lobehub/icons';
+
+export default () => TheGrid.colorPrimary;
+```
+
+## Avatars
+
+<DocsPreview>
+  <Flexbox gap={8} horizontal>
+    <TheGrid.Avatar size={64} />
+    <TheGrid.Avatar shape={'square'} size={64} />
+  </Flexbox>
+</DocsPreview>
+
+```tsx
+import { TheGrid } from '@lobehub/icons';
+
+export default () => <TheGrid.Avatar size={64} />;
+```

--- a/src/TheGrid/index.ts
+++ b/src/TheGrid/index.ts
@@ -1,0 +1,19 @@
+import Avatar from './components/Avatar';
+import Color from './components/Color';
+import Mono from './components/Mono';
+import { COLOR_PRIMARY, TITLE } from './style';
+
+export type CompoundedIcon = typeof Mono & {
+  Avatar: typeof Avatar;
+  Color: typeof Color;
+  colorPrimary: string;
+  title: string;
+};
+
+const Icons = Mono as CompoundedIcon;
+Icons.Color = Color;
+Icons.Avatar = Avatar;
+Icons.colorPrimary = COLOR_PRIMARY;
+Icons.title = TITLE;
+
+export default Icons;

--- a/src/TheGrid/style.ts
+++ b/src/TheGrid/style.ts
@@ -1,0 +1,7 @@
+export const TITLE = 'The Grid';
+export const COLOR_PRIMARY = '#0049E6';
+
+// Avatar constants
+export const AVATAR_BACKGROUND = COLOR_PRIMARY;
+export const AVATAR_COLOR = '#fff';
+export const AVATAR_ICON_MULTIPLE = 0.7;

--- a/src/features/providerConfig.tsx
+++ b/src/features/providerConfig.tsx
@@ -119,6 +119,7 @@ import TII from '@/TII';
 import Targon from '@/Targon';
 import Tencent from '@/Tencent';
 import TencentCloud from '@/TencentCloud';
+import TheGrid from '@/TheGrid';
 import Together from '@/Together';
 import Upstage from '@/Upstage';
 import V0 from '@/V0';
@@ -395,6 +396,7 @@ export const providerMappings: ProviderMapping[] = [
   { Icon: Ai302, combineMultiple: 0.9, keywords: [ModelProvider.Ai302] },
   { Icon: AiHubMix, combineMultiple: 0.9, keywords: [ModelProvider.AiHubMix] },
   { Icon: CometAPI, keywords: [ModelProvider.CometAPI] },
+  { Icon: TheGrid, keywords: [ModelProvider.TheGrid] },
   {
     Combine: memo(({ size = 24, ...props }) => (
       <Combine

--- a/src/features/providerEnum.ts
+++ b/src/features/providerEnum.ts
@@ -130,6 +130,7 @@ export enum ModelProvider {
   Targon = 'targon',
   Tencent = 'tencent',
   TencentCloud = 'tencentcloud',
+  TheGrid = 'thegrid',
   TogetherAI = 'togetherai',
   Upstage = 'upstage',
   V0 = 'v0',

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -285,6 +285,7 @@ export { default as Targon, type CompoundedIcon as TargonProps } from './Targon'
 export { default as Tavily, type CompoundedIcon as TavilyProps } from './Tavily';
 export { default as Tencent, type CompoundedIcon as TencentProps } from './Tencent';
 export { default as TencentCloud, type CompoundedIcon as TencentCloudProps } from './TencentCloud';
+export { default as TheGrid, type CompoundedIcon as TheGridProps } from './TheGrid';
 export { default as Tiangong, type CompoundedIcon as TiangongProps } from './Tiangong';
 export { default as TII, type CompoundedIcon as TIIProps } from './TII';
 export { default as Together, type CompoundedIcon as TogetherProps } from './Together';


### PR DESCRIPTION
## What

Adds **The Grid** brand icon, in both the web (`src/TheGrid`) and react-native (`packages/react-native/src/icons/TheGrid`) trees, plus the enum/config/barrel registrations in each.

Pairs with lobehub/lobehub#19194, which adds The Grid as a provider.

## Shape

`Mono` + `Color` + `Avatar` on the web side, `Mono` + `Avatar` for react-native — following the **V0** entry, which ships without a wordmark.

No `Text`/`Combine`: The Grid's logotype isn't something I can reproduce faithfully as traced paths, and I'd rather not approximate a wordmark. The `Icon`-only registry entry renders correctly without one. Happy to add both later if the design team supplies the lockup.

## Sources

- Glyph: the same 24×24 mark already carried in The Grid's [models.dev provider entry](https://github.com/sst/models.dev/tree/main/providers/the-grid-ai) — 12 paths, no changes beyond `currentColor` → `{COLOR_PRIMARY}` for the color variant.
- `COLOR_PRIMARY = '#0049E6'` — taken from `<meta name="theme-color">` on thegrid.ai, not eyeballed.

## Verification

All 15 added/modified files parse clean. Registration counts match an existing provider one-for-one across both trees (`icons.ts`/`index.ts` barrel, `providerEnum.ts`, `providerConfig.tsx`).

Disclosure: I work on The Grid.
